### PR TITLE
Add SkillResponse.d.ts to files section in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "lib/src/Device.d.ts",
     "lib/src/Index.d.ts",
     "lib/src/SkillContext.d.ts",
+    "lib/src/SkillResponse.d.ts",
     "lib/src/SkillSession.d.ts",
     "lib/src/User.d.ts",
     "lib/src/VirtualAlexa.d.ts"


### PR DESCRIPTION
This fixes the following tsc error with version 0.4.3:

```
node_modules/virtual-alexa/lib/src/VirtualAlexa.d.ts:3:31 - error TS7016: Could not find a declaration file for module './SkillResponse'.
```