### PR TITLE
Export SkillResponse

### DIFF
--- a/src/Index.ts
+++ b/src/Index.ts
@@ -1,3 +1,4 @@
 export {SkillContext} from "./SkillContext";
+export {SkillResponse} from "./SkillResponse";
 export {SkillSession} from "./SkillSession";
 export {RequestFilter, VirtualAlexa, VirtualAlexaBuilder} from "./VirtualAlexa";


### PR DESCRIPTION
Since the public API methods `launch`, `intend` and `utter` are resolving with a `SkillResponse`, this class should be exported so it can be used in annotations, e.g. in a test helper:

```ts
import {SkillResponse} from 'virtual-alexa';

function expectSomeOutput(output: SkillResponse): void {
  // expect something
}
```

```ts
const output = await alexa.launch();
expectSomeOutput(output);
```