### PR TITLE
Wait on audio player intents

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "virtual-alexa",
-  "version": "0.6.4-0",
+  "version": "0.6.4-1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -337,7 +337,7 @@
     "aws4": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.7.0.tgz",
-      "integrity": "sha512-32NDda82rhwD9/JBCCkB+MRYDp0oSvlo2IL6rQWA10PQi7tDUM3eqMSltXmY+Oyl/7N3P3qNtAlv7X0d9bI28w==",
+      "integrity": "sha1-1NDpudv8p3vwjusKikcVUP454ok=",
       "dev": true
     },
     "babel-code-frame": {
@@ -867,7 +867,7 @@
     "esprima": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
-      "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
+      "integrity": "sha1-RJnt3NERDgshi6zy+n9/WfVcqAQ=",
       "dev": true
     },
     "esutils": {
@@ -2122,13 +2122,13 @@
     "mime-db": {
       "version": "1.33.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
-      "integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ==",
+      "integrity": "sha1-o0kgUKXLm2NFBUHjnZeI0icng9s=",
       "dev": true
     },
     "mime-types": {
       "version": "2.1.18",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
-      "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
+      "integrity": "sha1-bzI/YKg9ERRvgx/xH9ZuL+VQO7g=",
       "dev": true,
       "requires": {
         "mime-db": "1.33.0"
@@ -5294,7 +5294,7 @@
     "qs": {
       "version": "6.5.2",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+      "integrity": "sha1-yzroBuh0BERYTvFUzo7pjUA/PjY="
     },
     "querystring": {
       "version": "0.2.0",
@@ -6019,7 +6019,7 @@
     "tough-cookie": {
       "version": "2.3.4",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
-      "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
+      "integrity": "sha1-7GDO44rGdQY//JelwYlwV47oNlU=",
       "dev": true,
       "requires": {
         "punycode": "1.4.1"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "virtual-alexa",
   "license": "Apache-2.0",
   "private": false,
-  "version": "0.6.4-0",
+  "version": "0.6.4-1",
   "main": "./lib/src/Index.js",
   "typings": "./lib/src/Index.d.ts",
   "engines": {

--- a/src/audioPlayer/AudioPlayer.ts
+++ b/src/audioPlayer/AudioPlayer.ts
@@ -196,9 +196,9 @@ export class AudioPlayer {
         return audioItem;
     }
 
-    private playNext(): Promise<any | undefined> {
+    private async playNext() {
         if (this._queue.length === 0) {
-            return Promise.resolve();
+            return;
         }
 
         this._playing = this.dequeue();

--- a/test/AudioPlayerTest.ts
+++ b/test/AudioPlayerTest.ts
@@ -71,10 +71,14 @@ describe("AudioPlayer launches and plays a track", function() {
             assert.include(result.response.outputSpeech.ssml, "Welcome to the Simple Audio Player");
 
             result = await virtualAlexa.utter("play") as SkillResponse;
+            // Make sure playback started has been sent before the response is received
+            assert.equal(requests.length, 3);
             assert.include(result.response.directives[0].audioItem.stream.url, "episode-013");
 
             result = await virtualAlexa.utter("next") as SkillResponse;
             assert.include(result.response.directives[0].audioItem.stream.url, "episode-012");
+            // Make sure another playback started has been sent before the response is received
+            assert.equal(requests[5].type, "AudioPlayer.PlaybackStarted");
 
             result = await virtualAlexa.utter("previous") as SkillResponse;
             assert.include(result.response.directives[0].audioItem.stream.url, "episode-013");
@@ -91,6 +95,11 @@ describe("AudioPlayer launches and plays a track", function() {
             assert.equal(requests[6].type, "AudioPlayer.PlaybackStopped");
             assert.equal(requests[7].type, "IntentRequest");
             assert.equal(requests[8].type, "AudioPlayer.PlaybackStarted");
+            // The ignored intent generates these requests
+            assert.equal(requests[9].type, "AudioPlayer.PlaybackStopped");
+            assert.equal(requests[10].type, "IntentRequest");
+            assert.equal(requests[11].type, "AudioPlayer.PlaybackStarted");
+            assert.equal(requests.length, 12);
         } catch (e) {
             assert.fail(e);
         }


### PR DESCRIPTION
This change is necessary for testing audio-player skills that have async operations in them.

Events can be thrown out of sequence when this is the case.