### PR TITLE
Better error message when dialog slot type is not matched

### DIFF
--- a/src/dialog/DialogManager.ts
+++ b/src/dialog/DialogManager.ts
@@ -93,6 +93,11 @@ export class DialogManager {
             // Loop through slot values looking for a match
             for (const slot of this._dialogIntent.slots) {
                 const slotType = this.context.interactionModel().slotTypes.slotType(slot.type);
+                if (!slotType) {
+                    throw new Error("No match in interaction model for slot type: "
+                        + slot.type + " on slot: " + slot.name);
+                }
+
                 const match = slotType.match(utterance);
                 if (match.matches) {
                     matched = true;


### PR DESCRIPTION
Based on this interaction in intercom, identified spot for better error-handling:
```
Cannot read property 'match' of undefined

TypeError: Cannot read property 'match' of undefined



at DialogManager.Object.<anonymous>.DialogManager.handleUtterance (../.npm-global/lib/node_modules/bespoken-tools/node_modules/skill-testing-ml/node_modules/virtual-alexa/lib/src/dialog/DialogManager.js:84:38)

at LocalSkillInteractor.Object.<anonymous>.SkillInteractor.spoken (../.npm-global/lib/node_modules/bespoken-tools/node_modules/skill-testing-ml/node_modules/virtual-alexa/lib/src/impl/SkillInteractor.js:60:53)

at VirtualAlexa.Object.<anonymous>.VirtualAlexa.utter (../.npm-global/lib/node_modules/bespoken-tools/node_modules/skill-testing-ml/node_modules/virtual-alexa/lib/src/core/VirtualAlexa.js:53:33)

at VirtualAlexaInvoker.<anonymous> (../.npm-global/lib/node_modules/bespoken-tools/node_modules/skill-testing-ml/dist/lib/runner/VirtualAlexaInvoker.js:118:61)

at step (../.npm-global/lib/node_modules/bespoken-tools/node_modules/skill-testing-ml/dist/lib/runner/VirtualAlexaInvoker.js:3:191)

at ../.npm-global/lib/node_modules/bespoken-tools/node_modules/skill-testing-ml/dist/lib/runner/VirtualAlexaInvoker.js:3:437

at VirtualAlexaInvoker.<anonymous> (../.npm-global/lib/node_modules/bespoken-tools/node_modules/skill-testing-ml/dist/lib/runner/VirtualAlexaInvoker.js:3:99)

at VirtualAlexaInvoker.invoke (../.npm-global/lib/node_modules/bespoken-tools/node_modules/skill-testing-ml/dist/lib/runner/VirtualAlexaInvoker.js:125:30)

at TestRunner.<anonymous> (../.npm-global/lib/node_modules/bespoken-tools/node_modules/skill-testing-ml/dist/lib/runner/TestRunner.js:143:50)

at step (../.npm-global/lib/node_modules/bespoken-tools/node_modules/skill-testing-ml/dist/lib/runner/TestRunner.js:3:191)

at ../.npm-global/lib/node_modules/bespoken-tools/node_modules/skill-testing-ml/dist/lib/runner/TestRunner.js:3:361
```