### PR TITLE
fix(audio-player): better error message for undefined stream url

### DIFF
--- a/src/audioPlayer/AudioPlayer.ts
+++ b/src/audioPlayer/AudioPlayer.ts
@@ -203,7 +203,12 @@ export class AudioPlayer {
 
         this._playing = this.dequeue();
         // If the URL for AudioItem is http, we throw an error
-        if (this._playing.stream.url.startsWith("http:")) {
+        if (!this._playing.stream.url) {
+            return this._interactor.sessionEnded(SessionEndedReason.ERROR, {
+                message: "The URL specified must be defined and a valid HTTPS url",
+                type: "INVALID_RESPONSE",
+            });  
+        } else if (this._playing.stream.url.startsWith("http:")) {
             return this._interactor.sessionEnded(SessionEndedReason.ERROR, {
                 message: "The URL specified in the Play directive must be HTTPS",
                 type: "INVALID_RESPONSE",

--- a/src/audioPlayer/AudioPlayer.ts
+++ b/src/audioPlayer/AudioPlayer.ts
@@ -205,7 +205,7 @@ export class AudioPlayer {
         // If the URL for AudioItem is http, we throw an error
         if (!this._playing.stream.url) {
             return this._interactor.sessionEnded(SessionEndedReason.ERROR, {
-                message: "The URL specified must be defined and a valid HTTPS url",
+                message: "The URL specified in the Play directive must be defined and a valid HTTPS url",
                 type: "INVALID_RESPONSE",
             });  
         } else if (this._playing.stream.url.startsWith("http:")) {

--- a/test/AudioPlayerTest.ts
+++ b/test/AudioPlayerTest.ts
@@ -1,6 +1,6 @@
-import {assert} from "chai";
-import {SkillResponse} from "../src/core/SkillResponse";
-import {VirtualAlexa} from "../src/core/VirtualAlexa";
+import { assert } from "chai";
+import { SkillResponse } from "../src/core/SkillResponse";
+import { VirtualAlexa } from "../src/core/VirtualAlexa";
 
 const interactionModel = {
     intents: [
@@ -11,6 +11,10 @@ const interactionModel = {
         {
             name: "Play",
             samples: ["play", "play next", "play now"],
+        },
+        {
+            name: "PlayUndefined",
+            samples: ["play undefined"],
         },
         {
             name: "AMAZON.NextIntent",
@@ -51,6 +55,30 @@ describe("AudioPlayer launches and plays a track", function() {
             console.log(e);
         }
 
+    });
+
+    it("Should not play an undefined track", async () => {
+        const virtualAlexa = VirtualAlexa.Builder()
+            .handler("test/resources/SimpleAudioPlayer.handler")
+            .interactionModel(interactionModel)
+            .create();
+
+        try {
+            // We capture the requests being sent to virtual alexa
+            // Because the AudioPlayer does some stuff internally automatically, want to ensure it is working properly
+            const requests: any[] = [];
+            virtualAlexa.filter((json) => {
+                requests.push(json.request);
+            });
+
+            let result = await virtualAlexa.launch() as SkillResponse;
+            assert.include(result.response.outputSpeech.ssml, "Welcome to the Simple Audio Player");
+
+            result = await virtualAlexa.utter("play undefined") as SkillResponse;
+        } catch (e) {
+            assert.equal(e.message, "The URL specified in the Play directive must be defined and a valid HTTPS url");
+            assert.equal(e.type, "INVALID_RESPONSE");
+        }
     });
 
     it("Plays a track, next then previous", async () => {

--- a/test/AudioPlayerTest.ts
+++ b/test/AudioPlayerTest.ts
@@ -1,6 +1,6 @@
-import { assert } from "chai";
-import { SkillResponse } from "../src/core/SkillResponse";
-import { VirtualAlexa } from "../src/core/VirtualAlexa";
+import {assert} from "chai";
+import {SkillResponse} from "../src/core/SkillResponse";
+import {VirtualAlexa} from "../src/core/VirtualAlexa";
 
 const interactionModel = {
     intents: [

--- a/test/resources/SimpleAudioPlayer.js
+++ b/test/resources/SimpleAudioPlayer.js
@@ -13,7 +13,7 @@ var podcastFeed = [
 var started = false;
 var stopped = false;
 // Entry-point for the Lambda
-exports.handler = function (event, context) {
+exports.handler = function(event, context) {
     var player = new SimplePlayer(event, context);
     player.handle();
 };
@@ -215,7 +215,7 @@ SimplePlayer.prototype.loadLastPlayed = function (userId) {
     return lastPlayed;
 };
 
-var indexFromEvent = function (event) {
+var indexFromEvent = function(event) {
     var index = 0;
     if (event) {
         // Turn it into an index - we will add or subtract if the user said next or previous

--- a/test/resources/SimpleAudioPlayer.js
+++ b/test/resources/SimpleAudioPlayer.js
@@ -13,7 +13,7 @@ var podcastFeed = [
 var started = false;
 var stopped = false;
 // Entry-point for the Lambda
-exports.handler = function(event, context) {
+exports.handler = function (event, context) {
     var player = new SimplePlayer(event, context);
     player.handle();
 };
@@ -44,10 +44,10 @@ SimplePlayer.prototype.handle = function () {
 
         if (intent.name === "Play") {
             this.play(podcastFeed[podcastIndex], 0, "REPLACE_ALL", podcastIndex);
-
-        } if (intent.name === "Ignore") {
+        } else if (intent.name === "PlayUndefined") {
+            this.play(null, 0, "REPLACE_ALL", 0);
+        } else if (intent.name === "Ignore") {
             this.say("Ignoring", "You can say Play");
-
         } else if (intent.name === "AMAZON.NextIntent") {
             if (!started) {
                 throw new Error("This should not happen - started flag not set");
@@ -215,7 +215,7 @@ SimplePlayer.prototype.loadLastPlayed = function (userId) {
     return lastPlayed;
 };
 
-var indexFromEvent = function(event) {
+var indexFromEvent = function (event) {
     var index = 0;
     if (event) {
         // Turn it into an index - we will add or subtract if the user said next or previous


### PR DESCRIPTION
There was a bug in my code where my stream url was null and I was getting a cryptic error message:
```
TypeError: Cannot read property 'startsWith' of null

     at AudioPlayer.<anonymous> (node_modules/virtual-alexa/lib/src/audioPlayer/AudioPlayer.js:233:46)
     at step (node_modules/virtual-alexa/lib/src/audioPlayer/AudioPlayer.js:32:23)
     at Object.next (node_modules/virtual-alexa/lib/src/audioPlayer/AudioPlayer.js:13:53)
     at node_modules/virtual-alexa/lib/src/audioPlayer/AudioPlayer.js:7:71
     at Object.<anonymous>.__awaiter (node_modules/virtual-alexa/lib/src/audioPlayer/AudioPlayer.js:3:12)
     at AudioPlayer.Object.<anonymous>.AudioPlayer.playNext (node_modules/virtual-alexa/lib/src/audioPlayer/AudioPlayer.js:227:16)
     at AudioPlayer.<anonymous> (node_modules/virtual-alexa/lib/src/audioPlayer/AudioPlayer.js:183:41)
     at step (node_modules/virtual-alexa/lib/src/audioPlayer/AudioPlayer.js:32:23)
     at Object.next (node_modules/virtual-alexa/lib/src/audioPlayer/AudioPlayer.js:13:53)
```
I wasn't sure which paramter it was complaining about, so I had to look at the source code in `AudioPlayer.ts`.

This small check should return a more descriptive error message and let the developer know that it is the stream URL that is the problem.