### PR TITLE
Updates supported types in set method path parameter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.vim
 .idea
 
 node_modules

--- a/src/core/SkillRequest.ts
+++ b/src/core/SkillRequest.ts
@@ -281,7 +281,7 @@ export class SkillRequest {
      * @param path The dot-notation path for the property to set
      * @param value The value to set it to
      */
-    set(path: string, value: any): SkillRequest {
+    set(path: string|string[], value: any): SkillRequest {
         _.set(this.json(), path, value);
         return this;
     }


### PR DESCRIPTION
I recently found myself trying to add APL support in a launch request, however, because the required key `Alexa.Presentation.APL` has dots in it's name it wasn't possible using just a string. 

Lodash, which is what SkillRequest.set uses, allows for this use case by allowing one to use not only `string` but also `string[]` to specify the structure to modify. This PR makes it so the SkillRequest.set types are congruent with those of lodash


```ts
const launchResponse = await alexa
  .request()
  .launch()
  .set(
    ["context.System.device.supportedInterfaces", "Alexa.Presentation.APL"],
    {}
  )
  .send();

```