### PR TITLE
Add APL_USER_EVENT type request and require session if request type is it

### DIFF
--- a/src/core/SkillRequest.ts
+++ b/src/core/SkillRequest.ts
@@ -19,6 +19,7 @@ export class RequestType {
     public static AUDIO_PLAYER_PLAYBACK_NEARLY_FINISHED = "AudioPlayer.PlaybackNearlyFinished";
     public static AUDIO_PLAYER_PLAYBACK_STARTED = "AudioPlayer.PlaybackStarted";
     public static AUDIO_PLAYER_PLAYBACK_STOPPED = "AudioPlayer.PlaybackStopped";
+    public static APL_USER_EVENT = "Alexa.Presentation.APL.UserEvent";
 }
 
 export enum SessionEndedReason {
@@ -203,6 +204,7 @@ export class SkillRequest {
         //  we will make one first if there is not. It will then be ended.
         return (this._json.request.type === RequestType.LAUNCH_REQUEST
             || this._json.request.type === RequestType.DISPLAY_ELEMENT_SELECTED_REQUEST
+            || this._json.request.type === RequestType.APL_USER_EVENT
             || this._json.request.type === RequestType.INTENT_REQUEST
             || this._json.request.type === RequestType.SESSION_ENDED_REQUEST);
     }


### PR DESCRIPTION
## What

Add  `Alexa.Presentation.APL.UserEvent` type request and require session object if request type is it.

## Why

`Alexa.Presentation.APL.UserEvent` type request is the kind of request that is called from `SendEvent` command of APL.

https://developer.amazon.com/en-US/docs/alexa/alexa-presentation-language/apl-interface.html#userevent-request
https://developer.amazon.com/en-US/docs/alexa/alexa-presentation-language/apl-standard-commands.html#sendevent-command

Sometimes I want to mock this type input but can't because VirtualAlexa doesn't know it. More specifically, Session object is needed to mock this request, but doesn't include because `requiresSession` object doesn't return true if `Alexa.Presentation.APL.UserEvent`.

So I want to add `Alexa.Presentation.APL.UserEvent` and add session object if this type of request coming.

## How

Add `Alexa.Presentation.APL.UserEvent` type request to `RequestType` class by `APL_USER_EVENT` name. and return true if `APL_USER_EVENT` type request in `requiresSession`